### PR TITLE
test: cover MultiModelDDPStrategy

### DIFF
--- a/examples/pytorch/domain_templates/generative_adversarial_net.py
+++ b/examples/pytorch/domain_templates/generative_adversarial_net.py
@@ -36,6 +36,14 @@ if _TORCHVISION_AVAILABLE:
     import torchvision
 
 
+def _block(in_feat: int, out_feat: int, normalize: bool = True):
+    layers = [nn.Linear(in_feat, out_feat)]
+    if normalize:
+        layers.append(nn.BatchNorm1d(out_feat, 0.8))
+    layers.append(nn.LeakyReLU(0.2, inplace=True))
+    return layers
+
+
 class Generator(nn.Module):
     """
     >>> Generator(img_shape=(1, 8, 8))  # doctest: +ELLIPSIS +NORMALIZE_WHITESPACE
@@ -47,19 +55,11 @@ class Generator(nn.Module):
     def __init__(self, latent_dim: int = 100, img_shape: tuple = (1, 28, 28)):
         super().__init__()
         self.img_shape = img_shape
-
-        def block(in_feat, out_feat, normalize=True):
-            layers = [nn.Linear(in_feat, out_feat)]
-            if normalize:
-                layers.append(nn.BatchNorm1d(out_feat, 0.8))
-            layers.append(nn.LeakyReLU(0.2, inplace=True))
-            return layers
-
         self.model = nn.Sequential(
-            *block(latent_dim, 128, normalize=False),
-            *block(128, 256),
-            *block(256, 512),
-            *block(512, 1024),
+            *_block(latent_dim, 128, normalize=False),
+            *_block(128, 256),
+            *_block(256, 512),
+            *_block(512, 1024),
             nn.Linear(1024, int(math.prod(img_shape))),
             nn.Tanh(),
         )

--- a/examples/pytorch/domain_templates/generative_adversarial_net_ddp.py
+++ b/examples/pytorch/domain_templates/generative_adversarial_net_ddp.py
@@ -44,6 +44,14 @@ if _TORCHVISION_AVAILABLE:
     import torchvision
 
 
+def _block(in_feat: int, out_feat: int, normalize: bool = True):
+    layers = [nn.Linear(in_feat, out_feat)]
+    if normalize:
+        layers.append(nn.BatchNorm1d(out_feat, 0.8))
+    layers.append(nn.LeakyReLU(0.2, inplace=True))
+    return layers
+
+
 class Generator(nn.Module):
     """
     >>> Generator(img_shape=(1, 8, 8))  # doctest: +ELLIPSIS +NORMALIZE_WHITESPACE
@@ -56,18 +64,11 @@ class Generator(nn.Module):
         super().__init__()
         self.img_shape = img_shape
 
-        def block(in_feat, out_feat, normalize=True):
-            layers = [nn.Linear(in_feat, out_feat)]
-            if normalize:
-                layers.append(nn.BatchNorm1d(out_feat, 0.8))
-            layers.append(nn.LeakyReLU(0.2, inplace=True))
-            return layers
-
         self.model = nn.Sequential(
-            *block(latent_dim, 128, normalize=False),
-            *block(128, 256),
-            *block(256, 512),
-            *block(512, 1024),
+            *_block(latent_dim, 128, normalize=False),
+            *_block(128, 256),
+            *_block(256, 512),
+            *_block(512, 1024),
             nn.Linear(1024, int(math.prod(img_shape))),
             nn.Tanh(),
         )

--- a/tests/tests_pytorch/strategies/test_multi_model_ddp.py
+++ b/tests/tests_pytorch/strategies/test_multi_model_ddp.py
@@ -1,0 +1,95 @@
+# Copyright The Lightning AI team.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+from unittest import mock
+from unittest.mock import PropertyMock
+
+import torch
+from torch import nn
+
+from lightning.pytorch.strategies.ddp import MultiModelDDPStrategy
+
+
+def test_multi_model_ddp_setup_and_register_hooks():
+    class Parent(nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.gen = nn.Linear(1, 1)
+            self.dis = nn.Linear(1, 1)
+
+    model = Parent()
+    original_children = [model.gen, model.dis]
+
+    strategy = MultiModelDDPStrategy(parallel_devices=[torch.device("cpu")])
+
+    wrapped_modules = []
+    wrapped_device_ids = []
+
+    class DummyDDP(nn.Module):
+        def __init__(self, module: nn.Module, device_ids=None, **kwargs):
+            super().__init__()
+            self.module = module
+            wrapped_modules.append(module)
+            wrapped_device_ids.append(device_ids)
+
+    with mock.patch("lightning.pytorch.strategies.ddp.DistributedDataParallel", DummyDDP):
+        returned_model = strategy._setup_model(model)
+        assert returned_model is model
+        assert isinstance(model.gen, DummyDDP)
+        assert isinstance(model.dis, DummyDDP)
+        assert wrapped_modules == original_children
+        assert wrapped_device_ids == [None, None]
+
+        strategy.model = model
+        with mock.patch("lightning.pytorch.strategies.ddp._register_ddp_comm_hook") as register_hook:
+            with mock.patch.object(MultiModelDDPStrategy, "root_device", new_callable=PropertyMock) as root_device:
+                root_device.return_value = torch.device("cuda", 0)
+                strategy._register_ddp_hooks()
+
+        assert register_hook.call_count == 2
+        register_hook.assert_any_call(
+            model=model.gen,
+            ddp_comm_state=strategy._ddp_comm_state,
+            ddp_comm_hook=strategy._ddp_comm_hook,
+            ddp_comm_wrapper=strategy._ddp_comm_wrapper,
+        )
+        register_hook.assert_any_call(
+            model=model.dis,
+            ddp_comm_state=strategy._ddp_comm_state,
+            ddp_comm_hook=strategy._ddp_comm_hook,
+            ddp_comm_wrapper=strategy._ddp_comm_wrapper,
+        )
+
+
+def test_multi_model_ddp_register_hooks_cpu_noop():
+    class Parent(nn.Module):
+        def __init__(self) -> None:
+            super().__init__()
+            self.gen = nn.Linear(1, 1)
+            self.dis = nn.Linear(1, 1)
+
+    model = Parent()
+    strategy = MultiModelDDPStrategy(parallel_devices=[torch.device("cpu")])
+
+    class DummyDDP(nn.Module):
+        def __init__(self, module: nn.Module, device_ids=None, **kwargs):
+            super().__init__()
+            self.module = module
+
+    with mock.patch("lightning.pytorch.strategies.ddp.DistributedDataParallel", DummyDDP):
+        strategy.model = strategy._setup_model(model)
+
+    with mock.patch("lightning.pytorch.strategies.ddp._register_ddp_comm_hook") as register_hook:
+        strategy._register_ddp_hooks()
+
+    register_hook.assert_not_called()


### PR DESCRIPTION
## Summary
- add unit test for MultiModelDDPStrategy to ensure child modules are wrapped in DDP and hooks registered
- assert that DDP hooks are skipped on CPU to validate CPU-only behaviour
- refactor GAN DDP example to expose block helper as top-level function
- refactor GAN example to expose block helper as top-level function

## Testing
- `PYTHONPATH=src pytest tests/tests_pytorch/strategies/test_multi_model_ddp.py -q`
- `pre-commit run --files examples/pytorch/domain_templates/generative_adversarial_net.py` *(command not found)*
- `pip install pre-commit` *(failed: Could not find a version that satisfies the requirement pre-commit due to proxy restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_6890448988508330bf108672ff3caf4e